### PR TITLE
Add model hook to modify changeset CORE-1629

### DIFF
--- a/lib/paper_trail/record_trail.rb
+++ b/lib/paper_trail/record_trail.rb
@@ -393,7 +393,7 @@ module PaperTrail
       end
 
       #
-      # Note(Nick)
+      # Note(Nick) - OneCloud
       #
       # Hook allows recorded model an opportunity to update the changeset
       # before persisting but after any generic updates in the object_changes_adapter

--- a/lib/paper_trail/record_trail.rb
+++ b/lib/paper_trail/record_trail.rb
@@ -397,8 +397,8 @@ module PaperTrail
       #
       # Hook allows recorded model an opportunity to update the changeset
       # before persisting but after any generic updates in the object_changes_adapter
-      if @record.paper_trail_config[:before_changeset_save]
-        changes = @record.send(@record.paper_trail_config[:before_changeset_save], changes)
+      if @record.paper_trail_options[:before_changeset_save]
+        changes = @record.send(@record.paper_trail_options[:before_changeset_save], changes)
       end
 
       if @record.class.paper_trail.version_class.object_changes_col_is_json?

--- a/lib/paper_trail/record_trail.rb
+++ b/lib/paper_trail/record_trail.rb
@@ -392,6 +392,15 @@ module PaperTrail
         changes = PaperTrail.config.object_changes_adapter.diff(changes)
       end
 
+      #
+      # Note(Nick)
+      #
+      # Hook allows recorded model an opportunity to update the changeset
+      # before persisting but after any generic updates in the object_changes_adapter
+      if @record.paper_trail_config[:before_changeset_save]
+        changes = @record.send(@record.paper_trail_config[:before_changeset_save], changes)
+      end
+
       if @record.class.paper_trail.version_class.object_changes_col_is_json?
         changes
       else


### PR DESCRIPTION
## Description

This adds a config option/model hook in order to modify the changeset before persisting the value. This will allow us to update the changeset with a diff for values that were changed by the user, but encrypted before saving.

## Example

```rb
class Example < ApplicationRecord
  has_paper_trail before_changeset_save: :update_changeset

  def update_changeset(changes)
    changes.merge({ something: 'new' })
  end
end
```