### PR TITLE
Fixing before_changeset_save hook

### DIFF
--- a/lib/paper_trail/events/base.rb
+++ b/lib/paper_trail/events/base.rb
@@ -267,6 +267,15 @@ module PaperTrail
           # `HashWithIndifferentAccess`.
           changes = PaperTrail.config.object_changes_adapter.diff(changes.to_hash)
         end
+        
+        #
+        # Note(Nick) - OneCloud
+        #
+        # Hook allows recorded model an opportunity to update the changeset
+        # before persisting but after any generic updates in the object_changes_adapter
+        if @record.paper_trail_options[:before_changeset_save]
+          changes = @record.send(@record.paper_trail_options[:before_changeset_save], changes)
+        end
 
         if @record.class.paper_trail.version_class.object_changes_col_is_json?
           changes

--- a/lib/paper_trail/record_trail.rb
+++ b/lib/paper_trail/record_trail.rb
@@ -166,27 +166,6 @@ module PaperTrail
     # PT-AT extends this method to add its transaction id.
     #
     # @api private
-    def recordable_object_changes(changes)
-      if PaperTrail.config.object_changes_adapter
-        changes = PaperTrail.config.object_changes_adapter.diff(changes)
-      end
-
-      #
-      # Note(Nick) - OneCloud
-      #
-      # Hook allows recorded model an opportunity to update the changeset
-      # before persisting but after any generic updates in the object_changes_adapter
-      if @record.paper_trail_options[:before_changeset_save]
-        changes = @record.send(@record.paper_trail_options[:before_changeset_save], changes)
-      end
-
-      if @record.class.paper_trail.version_class.object_changes_col_is_json?
-        changes
-      else
-        PaperTrail.serializer.dump(changes)
-      end
-    end
-
     def data_for_update_columns
       {}
     end


### PR DESCRIPTION
We had a hook to run some code for encrypted changes that wasn't firing after we updated this gem for rails 6, this should fix that.